### PR TITLE
[CI]: Fix fork-PR checkout blocked by security guard, keep auto-approve/reject

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,40 @@
+name: PR Review
+
+on:
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - name: Download PR number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - uses: mate-academy/auto-approve-action@v2
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        with:
+          github-token: ${{ github.token }}
+          pull-request-number: ${{ steps.pr.outputs.number }}
+
+      - uses: mate-academy/auto-reject-action@v2
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        with:
+          github-token: ${{ github.token }}
+          pull-request-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,11 @@ jobs:
         run: pytest tests/
 
       - name: Save PR number
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
 
       - name: Upload PR number
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-number

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
-on: [push, pull_request_target]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:
@@ -9,9 +11,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Set Up Python 3.14
         uses: actions/setup-python@v2
@@ -22,16 +21,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
       - name: Run flake8
         run: flake8 app/
+
       - name: Run tests
         timeout-minutes: 5
         run: pytest tests/
-      - uses: mate-academy/auto-approve-action@v2
-        if: ${{ github.event.pull_request && success() }}
+
+      - name: Save PR number
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR number
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ github.token }}
-      - uses: mate-academy/auto-reject-action@v2
-        if: ${{ github.event.pull_request && failure() }}
-        with:
-          github-token: ${{ github.token }}
+          name: pr-number
+          path: pr-number.txt


### PR DESCRIPTION
## Summary

Student PRs stopped passing CI because GitHub hardened `actions/checkout` to refuse checking out fork PR code from a `pull_request_target` workflow (the "pwn request" guard). Our autograder used exactly that pattern (fork checkout + privileged token for auto-approve/reject), so every fork PR now fails at checkout regardless of the student's code.

This splits the workflow so untrusted student code never runs with a write-scoped token, while preserving the auto-approve / auto-reject verdict:

- **`test.yml`** now triggers on `pull_request` (read-only token, no secrets) and runs flake8 + pytest against the student's code via the default checkout. It uploads the PR number as an artifact.
- **`pr-review.yml`** triggers on `workflow_run` (trusted context, write token) once Test completes, reads the PR number, and posts the same approve (on success) or request-changes (on failure) review.

No more fork checkout in a privileged context, so the security guard no longer blocks it.

Note: `pr-review.yml` only arms once it is on the default branch (`master`).